### PR TITLE
Enable stats viewing and editing for all dates

### DIFF
--- a/src/app/weight/page.tsx
+++ b/src/app/weight/page.tsx
@@ -50,7 +50,6 @@ export default function WeightPage() {
 
   const weights = data.weights;
   const goalWeight = data.profile.goalWeight;
-  const plan = data.dayType === 'A' ? DAY_A : DAY_B;
 
   // TDEE Calculation
   const tdeeTracking = useMemo(() => {
@@ -99,8 +98,12 @@ export default function WeightPage() {
         const dayCheckedItems = data.checklist[dateStr] || [];
         const extraCals = data.extraCalories?.[dateStr] || 0;
 
+        // Get the plan for this specific date
+        const dayType = data.dayTypes?.[dateStr] || 'A';
+        const dayPlan = dayType === 'A' ? DAY_A : DAY_B;
+
         let dayCalories = extraCals;
-        plan.meals.forEach(meal => {
+        dayPlan.meals.forEach(meal => {
           meal.items.forEach(item => {
             if (dayCheckedItems.includes(item.id)) {
               dayCalories += item.calories;
@@ -140,7 +143,7 @@ export default function WeightPage() {
       weightsNeeded,
       weeklyTrend,
     };
-  }, [data.profile, data.weights, data.checklist, data.extraCalories, plan.meals]);
+  }, [data.profile, data.weights, data.checklist, data.extraCalories, data.dayTypes]);
 
   const movingAvg = getMovingAverage(weights);
   const chartData = weights.map((w, i) => ({

--- a/src/lib/data-store.tsx
+++ b/src/lib/data-store.tsx
@@ -29,8 +29,10 @@ export interface AppData {
   extraCalories: {
     [date: string]: number;
   };
-  // Current day type
-  dayType: 'A' | 'B';
+  // Day type per date (A or B)
+  dayTypes: {
+    [date: string]: 'A' | 'B';
+  };
   // Metadata
   lastSync?: string;
 }
@@ -49,7 +51,7 @@ const DEFAULT_DATA: AppData = {
   weights: [],
   checklist: {},
   extraCalories: {},
-  dayType: 'A',
+  dayTypes: {},
 };
 
 const LOCAL_STORAGE_KEY = 'cutboard_all_data';
@@ -64,7 +66,8 @@ interface DataContextType {
   toggleChecklistItem: (date: string, itemId: string) => void;
   setChecklistItems: (date: string, items: string[]) => void;
   setExtraCalories: (date: string, calories: number) => void;
-  setDayType: (type: 'A' | 'B') => void;
+  setDayType: (date: string, type: 'A' | 'B') => void;
+  getDayType: (date: string) => 'A' | 'B';
   forceSync: () => Promise<void>;
 }
 
@@ -260,10 +263,18 @@ export function DataProvider({ children }: { children: ReactNode }) {
     }));
   }, [updateData]);
 
-  // Set day type
-  const setDayType = useCallback((type: 'A' | 'B') => {
-    updateData(prev => ({ ...prev, dayType: type }));
+  // Set day type for a specific date
+  const setDayType = useCallback((date: string, type: 'A' | 'B') => {
+    updateData(prev => ({
+      ...prev,
+      dayTypes: { ...prev.dayTypes, [date]: type },
+    }));
   }, [updateData]);
+
+  // Get day type for a specific date (defaults to 'A' if not set)
+  const getDayType = useCallback((date: string): 'A' | 'B' => {
+    return data.dayTypes?.[date] || 'A';
+  }, [data.dayTypes]);
 
   // Force sync
   const forceSync = useCallback(async () => {
@@ -282,6 +293,7 @@ export function DataProvider({ children }: { children: ReactNode }) {
       setChecklistItems,
       setExtraCalories,
       setDayType,
+      getDayType,
       forceSync,
     }}>
       {children}


### PR DESCRIPTION
- Show stats (weight, loss, vs plan) for any selected date, not just today
- Store day type (A/B) per date instead of globally
- Add getDayType function to data store
- Show weight for selected date with ability to edit
- Update TDEE calculation to use correct plan per historical date
- Update day toggle buttons to reflect selected date's day type